### PR TITLE
Add writer monad

### DIFF
--- a/src/Cat/Diagram/Monad/Instances/Writer.lagda.md
+++ b/src/Cat/Diagram/Monad/Instances/Writer.lagda.md
@@ -1,0 +1,66 @@
+<!--
+```agda
+open import Cat.Diagram.Terminal
+open import Cat.Diagram.Product
+open import Cat.Monoidal.Instances.Cartesian
+open import Cat.Instances.Product
+open import Cat.Diagram.Limit.Base
+open import Cat.Diagram.Limit.Product
+open import Cat.Instances.Functor
+open import Cat.Instances.Functor.Limits
+open import Cat.Instances.Functor.Compose
+open import Cat.Monoidal.Base
+open import Cat.Monoidal.Diagram.Monoid
+open import Cat.Diagram.Monad
+open import Cat.Prelude
+```
+-->
+
+```agda
+module Cat.Diagram.Monad.Instances.Writer
+  {o ℓ} {C : Precategory o ℓ}
+  (terminal : Terminal C)
+  (products : ∀ A B → Product C A B)
+  (A : Precategory.Ob C) (A-monoid : Monoid-on (Cartesian-monoidal products terminal) A)
+  where
+
+open Monoid-on
+open Precategory C
+open Terminal
+open Monad
+open _=>_
+
+Cat[C,C]-terminal : Terminal Cat[ C , C ]
+Cat[C,C]-terminal .top = Const (terminal .top)
+Cat[C,C]-terminal .has⊤ F = contr (NT (λ _ → ! terminal) λ x y f → {!   !}) {!   !}
+
+Cat[C,C]-products : ∀ F G → Product Cat[ C , C ] F G
+Cat[C,C]-products F G = product where
+  open Product
+  open Binary-products C products
+
+  product : Product Cat[ C , C ] F G
+  product .apex = ×-functor F∘ Cat⟨ F , G ⟩
+  product .π₁ = {!   !}
+  product .π₂ = {!   !}
+  product .has-is-product = {!   !}
+    -- Limit→Product
+    --   Cat[ C , C ]
+    --   (functor-limit {!   !} (2-object-diagram Cat[ C , C ] F G))
+
+open Product (Cat[C,C]-products (Const A) Id)
+
+writer-monad : Monad C
+writer-monad .M = apex
+writer-monad .unit =
+  ⟨ const-nt (A-monoid .η) ∘nt Terminal.! Cat[C,C]-terminal
+  , idnt
+  ⟩
+writer-monad .mult =
+  ⟨ const-nt (A-monoid .μ) ∘nt {!   !} -- subst (apex F∘ apex =>_) {!   !} ⟨ {! π₁  !} , {!   !} ⟩
+  , subst (apex F∘ apex =>_) F∘-idl (π₂ ◆ π₂)
+  ⟩
+writer-monad .left-ident = {! _◆_  !}
+writer-monad .right-ident = {! subst  !}
+writer-monad .mult-assoc = {!   !}
+```


### PR DESCRIPTION
# Description

Add writer monad on a cartesian monoidal category.

## Checklist

Before submitting a merge request, please check the items below:

- [ ] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [ ] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [ ] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".

If a commit affects many files without adding any content and you don't
want your name to appear on those pages (for example, treewide refactorings
or reformattings), start the commit message with `chore:` or include the word
`NOAUTHOR` anywhere.
